### PR TITLE
Changed the directions overlay to be smaller if on a mobile device

### DIFF
--- a/starter-code/client/components/NYCMap.js
+++ b/starter-code/client/components/NYCMap.js
@@ -367,7 +367,7 @@ export default function NYCMap({ userId, loggedInOrNot, ...props }) {
             </div>
         )}
         
-        <div style={{ height: "70vh", width: "100vw" }}>
+        <div className="map-div">
             <Map
                 streetViewControl={false}
                 zoomControl={false}

--- a/starter-code/client/pages/signup.js
+++ b/starter-code/client/pages/signup.js
@@ -5,14 +5,14 @@ import { createClient } from '@supabase/supabase-js';
 import { Auth } from '@supabase/auth-ui-react';
 import { ThemeSupa } from '@supabase/auth-ui-shared';
 import { useRouter } from 'next/router'; // import useRouter remove this
-  
+
 require('dotenv').config();
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
-  
+
 const Signup = () => {
   const router = useRouter(); // initialize router
 
@@ -25,7 +25,7 @@ const Signup = () => {
         }
       }
     );
-  
+
     return () => {
       if (typeof unsubscribe === 'function') {
         unsubscribe();
@@ -36,15 +36,18 @@ const Signup = () => {
   return (
     <div>
       <div>
-        <Navbar/>
+        <Navbar />
       </div>
-      <Auth
-        supabaseClient={supabase}
-        appearance={{ theme: ThemeSupa }}
-        providers={['google', 'facebook', 'twitter', 'github']}
-      />        
+      {/* Add padding around login form and also set max width so it doesnt take up 100% width of bigger screens */}
+      <div style={{ padding: '16px', maxWidth: '700px', margin: '0 auto' }}>
+        <Auth
+          supabaseClient={supabase}
+          appearance={{ theme: ThemeSupa }}
+          providers={['google', 'facebook', 'twitter', 'github']}
+        />
+      </div>
       <div>
-        <Footer/>
+        <Footer />
       </div>
     </div>
   );

--- a/starter-code/client/styles/globals.css
+++ b/starter-code/client/styles/globals.css
@@ -16,6 +16,13 @@
     height: 100%vh; 
     width: 100%; 
     position: relative;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  .map-div {
+    width: 100vw;
+    height: 70vh;
   }
 
   @media (max-width: 600px) {
@@ -23,6 +30,14 @@
         height: 50vh; 
     }
 }
+/* size down map to 70% of width for bigger screen sizes */
+@media (min-width: 1200px) {
+  .map-div {
+    width: 70vw;
+    margin: 0 auto;
+  }
+}
+
   .overlay {
     width: 350px;
     max-height: 400px;
@@ -35,6 +50,7 @@
     padding: 16px;
     border-radius: 6px;
   }
+
 
   .start  {
     font-size: 18px;
@@ -75,6 +91,38 @@
   height: 1px;
   background-color: white;
   margin-top: 2px;
+}
+/* size down overlay for smaller screen sizes */
+@media (max-width: 600px) {
+  .overlay {
+    width: 200px;
+    max-height: 300px;
+  }
+
+  .start  {
+    font-size: 14px;
+  }
+  .end  {
+
+    font-size: 14px;
+  
+  }
+
+  .subinfo_container {
+    display: flex;
+    align-items: center;
+    font-size: 12px;
+    margin-bottom: 20px;
+  }
+
+  .subinfo_container p {
+    font-size: 12px;
+  
+  }
+  .steps {
+    font-size: 12px;
+  
+  }
 }
 
   .paragraph-light {


### PR DESCRIPTION
Restored the map size to its original setting, 70% of the width for larger screens. On mobile devices, the map automatically expands to fit the screen. The directions overlay and font size decrease for smaller mobile screens as well. 

<img width="1248" alt="Screenshot 2024-05-14 at 4 09 17 PM" src="https://github.com/csci-499-sp24/RateMyPotty/assets/158118903/0271107e-355b-4ffc-82e9-a88b9aff181a">

<img width="328" alt="Screenshot 2024-05-14 at 4 09 56 PM" src="https://github.com/csci-499-sp24/RateMyPotty/assets/158118903/3f875e31-92d6-4092-8349-94399b71cc6a">

Also, in signup.js,  added padding around the login form and established a max width to prevent it from stretching across the entire screen. 

<img width="351" alt="Screenshot 2024-05-14 at 4 23 30 PM" src="https://github.com/csci-499-sp24/RateMyPotty/assets/158118903/6f7be1b3-ff3f-437c-80e1-115d4c060f60">

<img width="1259" alt="Screenshot 2024-05-14 at 4 24 05 PM" src="https://github.com/csci-499-sp24/RateMyPotty/assets/158118903/172cf44c-7454-4926-b905-4b67a0a653f9">
